### PR TITLE
Fixed having to type in '/movies' in order to view the movie list

### DIFF
--- a/flaskr/movies.py
+++ b/flaskr/movies.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, render_template
 from flaskr.db import get_movies
 
-bp = Blueprint('movies', __name__, url_prefix='/movies')
+bp = Blueprint('', __name__, url_prefix='/')
 
 @bp.route('/', methods=['GET'])
 def movie_list():

--- a/flaskr/movies.py
+++ b/flaskr/movies.py
@@ -1,9 +1,13 @@
-from flask import Blueprint, request, render_template
+from flask import Flask, Blueprint, request, render_template, redirect
 from flaskr.db import get_movies
 
-bp = Blueprint('', __name__, url_prefix='/')
+bp = Blueprint('movies', __name__, url_prefix='/')
 
-@bp.route('/', methods=['GET'])
+@bp.route('movies/')
 def movie_list():
     movies = get_movies()
     return render_template('movies.html', movies=movies)
+
+@bp.route('/')
+def sendRedirect():
+    return redirect('movies/')


### PR DESCRIPTION
When you start up the website, you should immediately see the movie list instead of a 404 Not Found error

Changes:
- The blueprint in movies.py no longer includes 'movies' in it

issue #1